### PR TITLE
Fix the infinite connect / disconnect loop

### DIFF
--- a/MKSOutputDevice.py
+++ b/MKSOutputDevice.py
@@ -17,7 +17,7 @@ from cura.PrinterOutput.GenericOutputController import GenericOutputController
 from cura.Machines.ContainerTree import ContainerTree
 
 from PyQt5.QtWidgets import QFileDialog, QMessageBox
-from PyQt5.QtNetwork import QNetworkRequest, QTcpSocket, 
+from PyQt5.QtNetwork import QNetworkRequest, QTcpSocket
 from PyQt5.QtCore import QTimer, pyqtSignal, pyqtProperty, pyqtSlot, QCoreApplication, QByteArray
 from queue import Queue
 

--- a/MKSOutputDevice.py
+++ b/MKSOutputDevice.py
@@ -17,7 +17,7 @@ from cura.PrinterOutput.GenericOutputController import GenericOutputController
 from cura.Machines.ContainerTree import ContainerTree
 
 from PyQt5.QtWidgets import QFileDialog, QMessageBox
-from PyQt5.QtNetwork import QNetworkRequest, QTcpSocket
+from PyQt5.QtNetwork import QNetworkRequest, QTcpSocket, 
 from PyQt5.QtCore import QTimer, pyqtSignal, pyqtProperty, pyqtSlot, QCoreApplication, QByteArray
 from queue import Queue
 
@@ -487,7 +487,7 @@ class MKSOutputDevice(NetworkedPrinterOutputDevice):
         return False
     
     def isSocketInConnectedState(self) -> bool:
-        return self._socket is not None and self._socket.state() == 3 # QAbstractSocket::ConnectedState
+        return self._socket is not None and self._socket.state() == QTcpSocket.SocketState.ConnectedState # QAbstractSocket::ConnectedState
 
     def sendfile(self, file_name, file_str):
         data = QByteArray()


### PR DESCRIPTION
For issue: #281 

The issue is that the function[ `isSocketInConnectedState() `in `MKSOutputDevice.py`](https://github.com/Jeredian/mks-wifi-plugin/blob/develop/MKSOutputDevice.py#L490) attempts to check if the printer is connected by comparing the socket state to `int` 3. However, in Python, `enum`s cannot be directly compared to `int`s.  (https://docs.python.org/3/library/enum.html)

So while the `SocketState.ConnectedState` `enum` value is 3. `socket.state == 3` will ALWAYS return false. Replacing the `int` with the `enum` fixes this.