### PR TITLE
Remove unneeded qmlregister type

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -4,7 +4,6 @@ import os, json
 
 from . import MKSOutputDevicePlugin
 from . import MachineConfig
-from PyQt6.QtQml import qmlRegisterType
 from UM.i18n import i18nCatalog
 from UM.Version import Version
 from UM.Application import Application
@@ -16,10 +15,10 @@ catalog = i18nCatalog("cura")
 def getMetaData():
     return {}
 
+
 #   \param app The application that the plug-in needs to register with.
 def register(app):
     if match_version():
-        qmlRegisterType(MKSOutputDevicePlugin.MKSOutputDevicePlugin, "MKSPlugin", 1, 0, "MKSOutputDevicePlugin")
         return {
             "output_device": MKSOutputDevicePlugin.MKSOutputDevicePlugin(),
             "machine_action": MachineConfig.MachineConfig()

--- a/qml/MonitorItem.qml
+++ b/qml/MonitorItem.qml
@@ -4,7 +4,6 @@
 import QtQuick 6.0
 import UM 1.6 as UM
 import Cura 1.7 as Cura
-import MKSPlugin 1.0 as MKSPlugin
 
 import QtQuick.Controls 6.0
 import QtQuick.Layouts 6.0


### PR DESCRIPTION
In pyqt6 you can only register 60 types. If you install all plugins in Cura, you run into this issue. Since this type isn't used, its better to not register it as this leaves more breathing room for the rest