### PR TITLE
fix: fix issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-report-bug.yaml
+++ b/.github/ISSUE_TEMPLATE/1-report-bug.yaml
@@ -1,3 +1,4 @@
+---
 name: "🐞 Bug Report"
 description: Create a report to help us fix issues.
 labels: ["issue: bug", "status: pending"]
@@ -5,11 +6,11 @@ body:
 - type: markdown
   attributes:
     value: |
-      **Thank you for using MKS WiFi Plugin and wanting to report a bug.**
+      **Thank you for using MKS WiFi Plugin and for reporting a bug.**
       
       Before filing, please check if the issue already exists (either open or closed) by using the search bar on the issues page. If it does, comment there. Even if it's closed, we can reopen it based on your comment. 
       
-      Also, please note the plugin version in the title of the issue (for example "[BUG] [1.2.4] It doesn't work well with Cura 4.11.0"). Please do not write things like **Request** or **BUG** in the title, this is what labels are for.
+      Also, please note the plugin version in the title of the issue (for example "[1.2.4] It doesn't work well with Cura 4.11.0"). Please do not write things like **Request** or **BUG** in the title, this is what labels are for.
 - type: input
   attributes:
     label: Plugin Version
@@ -83,6 +84,7 @@ body:
   validations:
     required: true
 
+---
 
 <!--📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛
 

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yaml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yaml
@@ -1,3 +1,4 @@
+---
 name: "🚀 Feature Request"
 description: Suggest an idea for this project.
 labels: ["issue: enhancement", "status: pending"]
@@ -5,7 +6,7 @@ body:
 - type: markdown
   attributes:
     value: |
-      **Thank you for using MKS WiFi Plugin and wanting to suggest a new feature.**
+      **Thank you for using MKS WiFi Plugin and want to suggest a new feature.**
       
       Before filing, please check if the feature request already exists (either open or closed) by using the search bar on the issues page. If it does, comment there. Even if it's closed, we can reopen it based on your comment. 
       
@@ -43,6 +44,7 @@ body:
     label: Additional information & file uploads
     description: You can add pictures or files to visualize your feature request in the comments below.
 
+---
 
 <!--📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛
 

--- a/.github/ISSUE_TEMPLATE/3-documentation.yaml
+++ b/.github/ISSUE_TEMPLATE/3-documentation.yaml
@@ -1,24 +1,34 @@
+---
 name: "📚 Documentation"
 labels: ["issue: documentation", "status: pending"]
 description: 'Let us know if any documentation is missing or could be improved'
 
 body:
-  - type: textarea
-    attributes:
-      label: Describe your use-case which is not covered by existing documentation.
-      description: If it is easier to submit a documentation patch instead of writing an issue, just do it!
-    validations:
-      required: true
+- type: markdown
+  attributes:
+    value: |
+      **Thank you for using MKS WiFi Plugin and wanting to improve our documentation**
+      
+      Before filing, please check if the question already exists (either open or closed) by using the search bar on the issues page. If it does, comment there. Even if it's closed, we can reopen it based on your comment. 
+      
+      Please do not write things like **Request** or **BUG** in the title, this is what labels are for.
+- type: textarea
+  attributes:
+    label: Describe your use-case which is not covered by existing documentation.
+    description: If it is easier to submit a documentation patch instead of writing an issue, just do it!
+  validations:
+    required: true
 
-  - type: textarea
-    attributes:
-      label: Reference any relevant documentation, other materials or issues/pull requests that can be used for inspiration.
+- type: textarea
+  attributes:
+    label: Reference any relevant documentation, other materials or issues/pull requests that can be used for inspiration.
 
-  - type: textarea
-    attributes:
-      label: Are you interested in contributing to the documentation?
-      description: Indicate if this is something you would like to work on, and how we can best support you in doing so. More details [on contributing](https://github.com/PrintMakerLab/.github/blob/main/CONTRIBUTING.md)
+- type: textarea
+  attributes:
+    label: Are you interested in contributing to the documentation?
+    description: Indicate if this is something you would like to work on, and how we can best support you in doing so. More details [on contributing](https://github.com/PrintMakerLab/.github/blob/main/CONTRIBUTING.md)
 
+---
 
 <!--📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛
 

--- a/.github/ISSUE_TEMPLATE/4-question.yaml
+++ b/.github/ISSUE_TEMPLATE/4-question.yaml
@@ -1,3 +1,4 @@
+---
 name: "❓ Question"
 description: Ask a question related to this project.
 labels: ["issue: question", "status: pending"]
@@ -18,6 +19,7 @@ body:
   validations:
     required: true
 
+---
 
 <!--📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛📛
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Have questions or need support?
     url: https://t.me/mks_wifi_plugin_reception


### PR DESCRIPTION
# Description

after https://github.com/PrintMakerLab/mks-wifi-plugin/pull/398 issue template become broken

## Type of change
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Translations
- [ ] Documentation
- [ ] Other... Please describe:

## What is the current behavior?

Issue templates  not working


## What is the new behavior(if this is a feature change)?

Issue templates shall be available for users


# How has this been tested?

<!-- Please provide a clear description of how this change was tested and instructions so we can reproduce.
    For UI changes, include screenshots of the relevant page(s) before and after the change.
    For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
 -->

- [x] Oper issue tab
- [x] Click "new issue"
- [x] Verifies that all templates exist

or 

- [x] Go to the fix-issue-templates/.github/ISSUE_TEMPLATE
- [x] Open each of issue template
- [x] Verifies that no errors shown

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Does it closes one of the existing issues?

- [ ] Yes
- [x] No

<!-- If this PR closes an existing issue please add link to an open issue here: closes #XXXX (where XXXX - it's an issue number) -->


## Other information


# PR Checklist:
<!-- Please check if your PR fulfills the following requirements: -->
- [x] The pull request opens from the **issue/patch/feature/bugfix branch** (right side) and not main branch!
- [x] The pull request title, commit messages and code are follows our guidelines: [Contribution guide](https://github.com/PrintMakerLab/.github/blob/main/CONTRIBUTING.md) 
- [x] All commits are signed-off. See [How to sign-off commit](https://github.com/PrintMakerLab/.github/blob/main/how_to_sign-off_commits.md) 
- [x] The code changes are commented, particularly in hard-to-understand areas