### PR TITLE
fix: prevent preview from being disabled when printer selected

### DIFF
--- a/MachineConfig.py
+++ b/MachineConfig.py
@@ -274,7 +274,7 @@ class MachineConfig(MachineAction):
         global_container_stack = Application.getInstance().getGlobalContainerStack()
         if global_container_stack:
             meta_data = global_container_stack.getMetaData()
-            if Constants.SIMAGE in meta_data or Constants.GIMAGE in meta_data:
+            if Constants.SCREENSHOT_INDEX in meta_data or Constants.SIMAGE in meta_data or Constants.GIMAGE in meta_data:
                 return True
         return False
 

--- a/qml/MachineConfig.qml
+++ b/qml/MachineConfig.qml
@@ -21,12 +21,6 @@ Cura.MachineAction {
 
     property var printerSupportScreenshots: manager.supportScreenshot()
     property var printerScreenshotSizesList: manager.getScreenshotOptions()
-    property var printerScreenshotIndex: {
-        var sIndex = manager.getScreenshotIndex()
-
-        screenshotComboBox.currentIndex = sIndex
-        return sIndex
-    }
 
     function connectPrinter() {
         if(base.selectedPrinter) {
@@ -334,11 +328,10 @@ Cura.MachineAction {
                                     manager.setSimage("")
                                     manager.setGimage("")
                                     manager.setScreenshotIndex("")
-                                    screenshotComboBox.currentIndex = 0
                                 }
                                 simageTextInput.text = manager.getSimage()
                                 gimageTextInput.text = manager.getGimage()
-                                screenshotComboBox.currentIndex = printerScreenshotIndex
+                                screenshotComboBox.currentIndex = manager.getScreenshotIndex()
                             }
 
                             enabled: mksSupport.checked


### PR DESCRIPTION
# Description

This fixes saving and showing preview setting for FLSUN-QQS printer.

## Type of change
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Translations
- [ ] Documentation
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

When user selects printer without preview image settings (`simage`, `gimage` ), preview settings become disabled.


## What is the new behavior(if this is a feature change)?
<!-- Please describe the behavior after changes -->

- When a user selects a printer without image preview settings,
  - preview settings tab should remain enabled for the next load
- When user selects "custom" settings and set image preview settings
  - image preview settings should be saved and loaded next time
- When user selects "custom" settings, and left image preview settings empty 
  - preview settings become disabled next time

# How has this been tested?

<!-- Please provide a clear description of how this change was tested and instructions so we can reproduce.
    For UI changes, include screenshots of the relevant page(s) before and after the change.
    For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
 -->

#### Test case 1
- Open plugin settings
- Enable preview settings 
- Choose FLSUN-QQS printer
- Close plugin settings dialog
- Open it again and expect that FLSUN-QQS is selected, and preview settings **enabled**

#### Test case 2
- Open plugin settings
- Enable preview settings 
- Choose Custom
- Leave simage and gimage empty
- Close plugin settings dialog
- Open it again and expect that Custom is selected, and preview settings **disabled**

#### Test case 3
- Open plugin settings
- Enable preview settings 
- Choose Custom
- Set simage and gimage empty
- Close plugin settings dialog
- Open it again and expect that Custom is selected, and preview settings **enabled**

#### Test case 4
- Open plugin settings
- Enable preview settings 
- Choose Default
- Close plugin settings dialog
- Open it again and expect that Default is selected, and preview settings **enabled**
<br>

- [x] Tested on Mac OS

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Does it closes one of the existing issues?

- [ ] Yes
- [x] No

<!-- If this PR closes an existing issue please add link to an open issue here: closes #XXXX (where XXXX - it's an issue number) -->


## Other information


# PR Checklist:
<!-- Please check if your PR fulfills the following requirements: -->
- [x] The pull request opens from the **issue/patch/feature/bugfix branch** (right side) and not main branch!
- [x] The pull request title, commit messages and code are follows our guidelines: [Contribution guide](https://github.com/PrintMakerLab/.github/blob/main/CONTRIBUTING.md) 
- [x] All commits are signed-off. See [How to sign-off commit](https://github.com/PrintMakerLab/.github/blob/main/how_to_sign-off_commits.md) 
- [x] The code changes are commented, particularly in hard-to-understand areas